### PR TITLE
Reduce memory allocation by caching or reusing

### DIFF
--- a/src/image-data/bitmap.ts
+++ b/src/image-data/bitmap.ts
@@ -1,5 +1,7 @@
 import { palette } from '../base/index.js'
 
+const uInt8Cache: Map<string, Uint8ClampedArray> = new Map(); 
+
 // At odds with in-game behavior... doesn't enforce a size with stretching.
 export const bitmapTextToImageData = (key: string, text: string): ImageData => {
   const rows = text.trim().split("\n").map(x => x.trim())
@@ -8,7 +10,14 @@ export const bitmapTextToImageData = (key: string, text: string): ImageData => {
   if (!isRect) throw new Error(`Bitmap with key ${key} is not rectangular.`);
   const width = rows[0]!.length || 1
   const height = rows.length || 1
-  const data = new Uint8ClampedArray(width*height*4)
+
+  // If possible, use a cached Uint8ClampedArray
+  const cacheKey = width + ',' + height;
+  const data = uInt8Cache.get(cacheKey) ?? new Uint8ClampedArray(width*height*4)
+  data.fill(0)
+
+  // Add the Uint8ClampedArray to the cache if it doesn't already exist
+  if (!uInt8Cache.has(cacheKey)) uInt8Cache.set(cacheKey, data);
   
   const colors = Object.fromEntries(palette)
   

--- a/src/web/text.ts
+++ b/src/web/text.ts
@@ -2,9 +2,10 @@ import type { TextElement } from '../api.js'
 import { font, composeText } from '../base/index.js'
 import { makeCanvas } from './util.js'
 
+const img = new ImageData(160, 128)
+
 export const getTextImg = (texts: TextElement[]): CanvasImageSource => {
 	const charGrid = composeText(texts)
-	const img = new ImageData(160, 128)
 	img.data.fill(0)
 
 	for (const [i, row] of Object.entries(charGrid)) {


### PR DESCRIPTION
The visible result of these changes can only be seen on games that make heavy of use `setLegend`. The memory-intensive blocks of code were found through the [Firefox memory profiler](https://firefox-source-docs.mozilla.org/devtools-user/memory/).

On Firefox, these games would suffer from high memory usage and lag spikes from garbage collection. The same does not occur on Chromium-based browsers.

https://github.com/hackclub/sprig-engine/assets/24477470/7ac8153d-a48b-4caf-9644-a614f0985622

Games tested in the screen recording: [ROOM](https://sprig.hackclub.com/gallery/ROOM) and [Taiko Fever](https://sprig.hackclub.com/gallery/taiko_fever).

**Firefox**
ROOM on max resolution still lags and has occasional lockups even after these changes, because it's an absolute beast. When not run alongside 3 other RAM blackholes, Taiko Fever runs with very subtle lag spikes.

**Chrome**
ROOM on max resolution still lags sometimes but doesn't lock up for several seconds like before. Taiko Fever works great.